### PR TITLE
Updated index.ts to fix TS2666

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,6 @@ declare module "react-native-linear-gradient" {
         locations?: number[]
     }
 
-    export class LinearGradient extends React.Component<LinearGradientProps, any> { }
+    export default class LinearGradient extends React.Component<LinearGradientProps, any> { }
 
-    export default LinearGradient
 }


### PR DESCRIPTION
I was using this package as a temporary fix for react-native-community/react-native-linear-gradient#280 gets merged, but `tsc` kept throwing `TS2666: Exports and export assignments are not permitted in module augmentations`. This fixes that by moving the `default` keyword into the class signature.